### PR TITLE
Replace string-based type checks with structural inspection, add lint CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: CI
 
 on:
   push:
@@ -7,6 +7,16 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - run: ruff check decomp_magician/ tests/
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/decomp_magician/__main__.py
+++ b/decomp_magician/__main__.py
@@ -55,7 +55,10 @@ def _c(code: str, text: str) -> str:
     return text
 
 
-def format_tree(node: DecompNode, prefix: str = "", is_last: bool = True, is_root: bool = True, ancestor_has_dtensor: bool = False) -> str:
+def format_tree(
+    node: DecompNode, prefix: str = "", is_last: bool = True,
+    is_root: bool = True, ancestor_has_dtensor: bool = False,
+) -> str:
     """Format a DecompNode tree as a string with box-drawing characters."""
     lines = []
 
@@ -86,7 +89,10 @@ def format_tree(node: DecompNode, prefix: str = "", is_last: bool = True, is_roo
     child_prefix = prefix + ("    " if is_last else "│   ") if not is_root else ""
     for i, child in enumerate(node.children):
         is_last_child = i == len(node.children) - 1
-        lines.append(format_tree(child, child_prefix, is_last_child, is_root=False, ancestor_has_dtensor=this_has_dtensor))
+        lines.append(format_tree(
+            child, child_prefix, is_last_child,
+            is_root=False, ancestor_has_dtensor=this_has_dtensor,
+        ))
 
     return "\n".join(lines)
 
@@ -775,7 +781,8 @@ def _run_stats(args) -> int:
         traceable_with_children = dt.fully_covered + dt.has_gaps
         if traceable_with_children > 0:
             cov_pct = dt.fully_covered / traceable_with_children * 100
-            lines.append(f"  Fully covered trees:   {_c(_GREEN, str(dt.fully_covered))}/{traceable_with_children} ({cov_pct:.0f}%)")
+            covered_str = _c(_GREEN, str(dt.fully_covered))
+            lines.append(f"  Fully covered trees:   {covered_str}/{traceable_with_children} ({cov_pct:.0f}%)")
             lines.append(f"  Trees with gaps:       {_c(_RED, str(dt.has_gaps))}")
 
         if dt.top_uncovered:

--- a/decomp_magician/__main__.py
+++ b/decomp_magician/__main__.py
@@ -13,9 +13,7 @@ from typing import Callable, NamedTuple
 from decomp_magician.diff import compute_diff, compute_diff_ops
 from decomp_magician.dispatch import (
     DispatchInfo,
-    format_dispatch_detail,
     format_dispatch_short,
-    get_dispatch_info,
     get_dispatch_info_cached,
 )
 from decomp_magician.graph import format_dot, format_mermaid
@@ -231,7 +229,7 @@ def format_purity(result: PurityResult) -> str:
     if result.is_pure:
         lines.append(_c(_GREEN, "PURE") + f"  {result.op}")
         lines.append(f"  All {result.total_leaves} leaf ops are non-mutable with no ADIOV kernel.")
-        lines.append(f"  Behavior under inference_mode vs no_grad: " + _c(_GREEN, "identical"))
+        lines.append("  Behavior under inference_mode vs no_grad: " + _c(_GREEN, "identical"))
     else:
         lines.append(_c(_RED, "IMPURE") + f"  {result.op}")
         lines.append(f"  {result.total_leaves} leaf ops total")
@@ -255,10 +253,10 @@ def format_purity(result: PurityResult) -> str:
 
         if result.mode_sensitive_leaves:
             lines.append("")
-            lines.append(f"  Leaves differing under inference_mode vs no_grad: " +
-                         _c(_RED, f"{len(result.mode_sensitive_leaves)}"))
-            lines.append(f"  These leaves have autograd/ADIOV kernels whose dispatch")
-            lines.append(f"  path changes depending on the active gradient mode.")
+            lines.append("  Leaves differing under inference_mode vs no_grad: " +
+                         _c(_RED, str(len(result.mode_sensitive_leaves))))
+            lines.append("  These leaves have autograd/ADIOV kernels whose dispatch")
+            lines.append("  path changes depending on the active gradient mode.")
 
     return "\n".join(lines)
 
@@ -690,7 +688,7 @@ def _run_stats(args) -> int:
     trace_pct = data.traceable / data.total_non_out * 100 if data.total_non_out else 0
 
     lines = [
-        _c(_BOLD, f"Decomposition table statistics") + f"  ({mode} decomposition)",
+        _c(_BOLD, "Decomposition table statistics") + f"  ({mode} decomposition)",
         "",
         f"  Total ops in table:  {data.total}  ({data.total_non_out} excluding _out variants)",
     ]
@@ -743,7 +741,7 @@ def _run_stats(args) -> int:
 
         lines.append("")
         lines.append(
-            _c(_BOLD, f"Leaf op coverage") +
+            _c(_BOLD, "Leaf op coverage") +
             f"  (target: {args.target_opset})"
         )
         lines.append(

--- a/decomp_magician/dispatch.py
+++ b/decomp_magician/dispatch.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from functools import lru_cache
 
 import torch
 from torch._ops import OpOverload

--- a/decomp_magician/tree.py
+++ b/decomp_magician/tree.py
@@ -151,14 +151,13 @@ def _make_arg(arg):
     (suitable for batch_norm, layer_norm, etc.). See _make_arg_with_shape
     for the retry variant where weight gets full-dimensional tensors.
     """
-    type_str = str(arg.type)
     kind = arg.type.kind()
 
     if kind == "TensorType":
         return _make_meta_tensor(arg.name)
 
     if kind == "OptionalType":
-        if "Tensor" in type_str:
+        if arg.type.getElementType().kind() == "TensorType":
             return _make_meta_tensor(arg.name)
         if arg.default_value is not None:
             return arg.default_value
@@ -350,7 +349,6 @@ def _make_arg_with_shape(arg, shape: list[int]):
     Optional "bias" args are set to None since bias size depends on weight
     shape in ways that vary by op (conv C_out vs batchnorm C).
     """
-    type_str = str(arg.type)
     kind = arg.type.kind()
 
     if kind == "TensorType":
@@ -370,7 +368,7 @@ def _make_arg_with_shape(arg, shape: list[int]):
         return torch.empty(shape, device="meta")
 
     if kind == "OptionalType":
-        if "Tensor" in type_str:
+        if arg.type.getElementType().kind() == "TensorType":
             name_lower = arg.name.lower()
             if name_lower in _SCALAR_NAMES:
                 return torch.empty([], device="meta")
@@ -439,15 +437,15 @@ def _fill_optional_scalars(op: OpOverload, args: list, kwargs: dict) -> tuple[li
             if not arg.kwarg_only:
                 pos_idx += 1
             continue
-        if "Tensor" in str(arg.type):
+        elem_kind = arg.type.getElementType().kind()
+        if elem_kind == "TensorType":
             if not arg.kwarg_only:
                 pos_idx += 1
             continue
-        elem = str(arg.type)
         fill_val = None
-        if "int" in elem:
+        if elem_kind == "IntType":
             fill_val = 0
-        elif "float" in elem or "number" in elem:
+        elif elem_kind in ("FloatType", "NumberType"):
             fill_val = 1.0
         if fill_val is None:
             if not arg.kwarg_only:
@@ -596,7 +594,6 @@ def _make_backward_arg(arg):
     bool for masks (these don't require grad). All other tensors are float
     with requires_grad=True.
     """
-    type_str = str(arg.type)
     kind = arg.type.kind()
 
     if kind == "TensorType":
@@ -608,7 +605,7 @@ def _make_backward_arg(arg):
         return torch.randn([2, 3], requires_grad=True)
 
     if kind == "OptionalType":
-        if "Tensor" in type_str:
+        if arg.type.getElementType().kind() == "TensorType":
             name_lower = arg.name.lower()
             if name_lower in _INDEX_NAMES:
                 return torch.zeros([2], dtype=torch.int64)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,9 @@ decomp-magician = "decomp_magician.__main__:main"
 [project.urls]
 Repository = "https://github.com/stmcgovern/decomposition-magician"
 Issues = "https://github.com/stmcgovern/decomposition-magician/issues"
+
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "W"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ Issues = "https://github.com/stmcgovern/decomposition-magician/issues"
 
 [tool.ruff]
 target-version = "py310"
+line-length = 120
 
 [tool.ruff.lint]
 select = ["E", "F", "W"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -490,14 +490,14 @@ class TestDtensorAncestorCoverage:
         leaf = self._make_node("missing")
         parent = self._make_node("decomp-fallback", children=[leaf])
         d = _leaves_to_dict(parent)
-        assert any(l.get("dtensor_uncovered") for l in d["leaves"])
+        assert any(entry.get("dtensor_uncovered") for entry in d["leaves"])
 
     def test_json_leaves_no_flag_when_covered(self):
         """JSON leaves output should not include dtensor_uncovered when covered."""
         leaf = self._make_node("missing")
         parent = self._make_node("registered", children=[leaf])
         d = _leaves_to_dict(parent)
-        assert not any(l.get("dtensor_uncovered") for l in d["leaves"])
+        assert not any(entry.get("dtensor_uncovered") for entry in d["leaves"])
 
     def test_cli_dtensor_decomposable_root_not_missing(self, capsys):
         """A decomposable op's root should never show dtensor: MISSING.

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -4,7 +4,6 @@ import torch
 
 from decomp_magician.dispatch import (
     DispatchEntry,
-    DispatchInfo,
     get_dispatch_info,
     get_dispatch_info_cached,
     format_dispatch_short,


### PR DESCRIPTION
## Summary

- All schema type checks now use `arg.type.getElementType().kind()` instead of string matching against `str(arg.type)`. The string approach silently broke for `.vec` overloads (`Optional[List[int]]` vs `int[]?`) and would break again for any future schema representation change.
- Adds a `ruff` lint job to CI and fixes all existing lint violations (unused imports, f-strings without placeholders, ambiguous variable names).
- Renames CI workflow from "Tests" to "CI" and adds the lint job as a parallel gate.

## Changes

**`tree.py`** — eliminate all `str(arg.type)` patterns:
- `_make_arg`: `"Tensor" in type_str` → `getElementType().kind() == "TensorType"`
- `_make_arg_with_shape`: same fix
- `_make_backward_arg`: same fix
- `_fill_optional_scalars`: `"int" in str()` → `getElementType().kind() in ("IntType", ...)` 
- Remove now-unused `type_str` local variables

**`__main__.py`** — lint fixes:
- Remove unused imports (`format_dispatch_detail`, `get_dispatch_info`)
- Fix 5 f-strings that had no placeholders

**`dispatch.py`** — remove unused `lru_cache` import

**`tests/`** — fix ambiguous variable `l` → `entry`, remove unused `DispatchInfo` import

**CI** — add parallel `lint` job running `ruff check`

## Test plan

- [x] All 266 tests pass
- [x] `ruff check decomp_magician/ tests/` passes clean
- [ ] CI runs on this PR