### PR TITLE
Separate DTensor strategy as independent cached lookup

### DIFF
--- a/decomp_magician/classify.py
+++ b/decomp_magician/classify.py
@@ -67,18 +67,12 @@ class OpClass:
     has_alias_info: bool = False
     inductor_kept: bool = False
     op_category: OpCategory = OpCategory.OTHER
-    dtensor_strategy: DtensorStrategy = DtensorStrategy.MISSING
 
     def __post_init__(self):
         if self.decomp_type not in DECOMP_TYPES:
             raise ValueError(
                 f"Invalid decomp_type {self.decomp_type!r}, "
                 f"expected one of {sorted(DECOMP_TYPES)}"
-            )
-        if self.dtensor_strategy not in DTENSOR_STRATEGIES:
-            raise ValueError(
-                f"Invalid dtensor_strategy {self.dtensor_strategy!r}, "
-                f"expected one of {sorted(DTENSOR_STRATEGIES)}"
             )
         if self.inductor_kept and self.decomp_type not in (
             DecompType.TABLE, DecompType.BOTH,
@@ -332,7 +326,7 @@ def _get_op_category(op: OpOverload, has_tensor_input: bool) -> OpCategory:
 
     Args:
         has_tensor_input: Whether the op has any tensor arguments.
-            Pre-computed by the caller — shared with _get_dtensor_strategy.
+            Pre-computed by the caller to avoid redundant schema walks.
     """
     tags = op.tags
 
@@ -363,18 +357,33 @@ def _get_op_category(op: OpOverload, has_tensor_input: bool) -> OpCategory:
     return OpCategory.OTHER
 
 
-def _get_dtensor_strategy(
-    op: OpOverload, has_decomp: bool, has_tensor_input: bool,
-) -> DtensorStrategy:
-    """Check DTensor sharding strategy registration status.
+_dtensor_cache: dict[OpOverload, DtensorStrategy] = {}
 
-    Args:
-        has_decomp: Whether the op has any decomposition (table or CIA).
-        has_tensor_input: Whether the op has any tensor arguments.
-        Both are pre-computed by classify() to avoid redundant work and
-        to make the shared dependency between OpCategory and DtensorStrategy
-        explicit.
+
+def get_dtensor_strategy(op: OpOverload) -> DtensorStrategy:
+    """Look up DTensor sharding strategy registration for an op.
+
+    Combines DTensor's own registration dicts with decomposability from
+    classify(). The result is a priority cascade:
+
+        REGISTERED      =  R            (ShardingPropagator has a handler)
+        DECOMP_FALLBACK = ¬R ∧ (F ∨ D)  (some decomposition handles it)
+        NOT_APPLICABLE  = ¬R ∧ ¬F ∧ ¬D ∧ ¬T  (unreachable by DTensor dispatch)
+        MISSING         = ¬R ∧ ¬F ∧ ¬D ∧  T  (reachable, no strategy)
+
+    where R = registered in ShardingPropagator,
+          F = DTensor's own decomp (DecompShardingStrategy),
+          D = standard decomposable (classify().decomp_type ≠ LEAF),
+          T = has tensor inputs.
+
+    Containment: MISSING ∪ NOT_APPLICABLE ⊆ {decomp_type = LEAF, no DTensor decomp}.
+
+    Results are globally cached.
     """
+    cached = _dtensor_cache.get(op)
+    if cached is not None:
+        return cached
+
     dt = _init_dtensor()
     prop = dt.propagator
     decomp_cls = dt.decomp_strategy_cls
@@ -382,27 +391,29 @@ def _get_dtensor_strategy(
     # Check registered strategies (DTensor has an explicit handler).
     # Attribute names vary across PyTorch versions, so guard each.
     if hasattr(prop, "op_strategy_funcs") and op in prop.op_strategy_funcs:
-        return DtensorStrategy.REGISTERED
-    if hasattr(prop, "op_single_dim_strategy_funcs") and op in prop.op_single_dim_strategy_funcs:
-        return DtensorStrategy.REGISTERED
-    if hasattr(prop, "op_to_rules") and op in prop.op_to_rules:
-        return DtensorStrategy.REGISTERED
-
+        result = DtensorStrategy.REGISTERED
+    elif hasattr(prop, "op_single_dim_strategy_funcs") and op in prop.op_single_dim_strategy_funcs:
+        result = DtensorStrategy.REGISTERED
+    elif hasattr(prop, "op_to_rules") and op in prop.op_to_rules:
+        result = DtensorStrategy.REGISTERED
     # Check DTensor's own decomposition awareness.
-    if decomp_cls is not None and decomp_cls.has_decomp(op):
-        return DtensorStrategy.DECOMP_FALLBACK
-
+    elif decomp_cls is not None and decomp_cls.has_decomp(op):
+        result = DtensorStrategy.DECOMP_FALLBACK
     # Ops with any decomposition (table or CIA) auto-decompose before
     # DTensor dispatch, so DTensor handles the children via fallback.
-    if has_decomp:
-        return DtensorStrategy.DECOMP_FALLBACK
-
+    # Reuse classify() instead of re-checking decomposition_table and
+    # _can_decompose() — keeps the decomposability answer in one place.
+    elif classify(op).decomp_type != DecompType.LEAF:
+        result = DtensorStrategy.DECOMP_FALLBACK
     # Factory/allocation ops have no tensor inputs, so DTensor dispatch
     # (which is input-driven via overloaded_args) can never reach them.
-    if not has_tensor_input:
-        return DtensorStrategy.NOT_APPLICABLE
+    elif not _has_tensor_input(op):
+        result = DtensorStrategy.NOT_APPLICABLE
+    else:
+        result = DtensorStrategy.MISSING
 
-    return DtensorStrategy.MISSING
+    _dtensor_cache[op] = result
+    return result
 
 
 _classify_cache: dict[OpOverload, OpClass] = {}
@@ -419,9 +430,6 @@ def classify(op: OpOverload) -> OpClass:
     if cached is not None:
         return cached
 
-    # Compute shared predicates once — these determine multiple classification axes.
-    # has_decomp: shared by DecompType and DtensorStrategy
-    # has_tensor_input: shared by OpCategory (FACTORY) and DtensorStrategy (NOT_APPLICABLE)
     from torch._decomp import decomposition_table
     in_table = op in decomposition_table
     has_cia = op._can_decompose()
@@ -437,9 +445,6 @@ def classify(op: OpOverload) -> OpClass:
         ),
         inductor_kept=op.name() in _get_inductor_kept_set(),
         op_category=_get_op_category(op, has_tensor_input=has_tensor_input),
-        dtensor_strategy=_get_dtensor_strategy(
-            op, has_decomp=in_table or has_cia, has_tensor_input=has_tensor_input,
-        ),
     )
     _classify_cache[op] = result
     return result

--- a/decomp_magician/cli.py
+++ b/decomp_magician/cli.py
@@ -248,7 +248,7 @@ def _run_tree(op, resolved_name: str, args, cfg: FormatConfig) -> int:
 
     if args.json:
         if args.leaves:
-            d = leaves_to_dict(node)
+            d = leaves_to_dict(node, include_dtensor=cfg.show_dtensor)
             if cfg.show_dispatch or cfg.show_mode_sensitivity:
                 d = enrich_leaves_with_dispatch(d, node)
             if args.target_opset:

--- a/decomp_magician/cli.py
+++ b/decomp_magician/cli.py
@@ -257,7 +257,7 @@ def _run_tree(op, resolved_name: str, args, cfg: FormatConfig) -> int:
                     leaf["in_opset"] = is_core_aten(leaf["op"])
                 d["opset"] = args.target_opset
         else:
-            d = tree_to_dict(node)
+            d = tree_to_dict(node, include_dtensor=cfg.show_dtensor)
             if cfg.show_dispatch or cfg.show_mode_sensitivity:
                 enrich_tree_with_dispatch(d, node)
         add_untraceable_warnings(d, node)
@@ -539,11 +539,10 @@ def _run_model(args, cfg: FormatConfig) -> int:
 
     dtensor_info: dict[str, str] = {}
     if args.dtensor:
-        from decomp_magician.classify import classify as classify_op
+        from decomp_magician.classify import get_dtensor_strategy
         for name, op_obj in op_objects.items():
             try:
-                cls = classify_op(op_obj)
-                dtensor_info[name] = cls.dtensor_strategy
+                dtensor_info[name] = get_dtensor_strategy(op_obj)
             except Exception:
                 dtensor_info[name] = DtensorStrategy.MISSING
 

--- a/decomp_magician/export.py
+++ b/decomp_magician/export.py
@@ -224,14 +224,14 @@ def tree_to_dict(node: DecompNode, *, include_dtensor: bool = False) -> dict:
     return d
 
 
-def leaves_to_dict(node: DecompNode) -> dict:
+def leaves_to_dict(node: DecompNode, *, include_dtensor: bool = False) -> dict:
     """Convert leaf frontier to a JSON-serializable dict."""
     root_name = op_display_name(node.op)
 
     if not node.children:
         return {"op": root_name, "decomp_type": DecompType.LEAF, "leaves": []}
 
-    lf = collect_leaf_frontier(node)
+    lf = collect_leaf_frontier(node, check_dtensor=include_dtensor)
 
     leaves = []
     for name, count in lf.counts.most_common():

--- a/decomp_magician/export.py
+++ b/decomp_magician/export.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from decomp_magician.classify import DecompType
+from decomp_magician.classify import DecompType, get_dtensor_strategy
 from decomp_magician.dispatch import DispatchInfo, get_dispatch_info_cached
 from decomp_magician.tree import (
     DecompNode,
@@ -200,7 +200,7 @@ def format_dot(node: DecompNode) -> str:
 # JSON dict conversions
 # ---------------------------------------------------------------------------
 
-def tree_to_dict(node: DecompNode) -> dict:
+def tree_to_dict(node: DecompNode, *, include_dtensor: bool = False) -> dict:
     """Convert a DecompNode tree to a JSON-serializable dict."""
     cls = node.classification
     d: dict = {
@@ -217,9 +217,10 @@ def tree_to_dict(node: DecompNode) -> dict:
     }
     if node.error:
         d["error"] = node.error
-    d["dtensor_strategy"] = cls.dtensor_strategy
+    if include_dtensor:
+        d["dtensor_strategy"] = get_dtensor_strategy(node.op)
     if node.children:
-        d["children"] = [tree_to_dict(c) for c in node.children]
+        d["children"] = [tree_to_dict(c, include_dtensor=include_dtensor) for c in node.children]
     return d
 
 

--- a/decomp_magician/format.py
+++ b/decomp_magician/format.py
@@ -173,7 +173,7 @@ def format_leaves(
     if not node.children:
         return f"{_c(cfg, _DIM, root_name)}  [leaf, no decomposition]"
 
-    lf = collect_leaf_frontier(node)
+    lf = collect_leaf_frontier(node, check_dtensor=cfg.show_dtensor)
 
     leaf_dispatch: dict = {}
     if cfg.show_dispatch or cfg.show_mode_sensitivity:

--- a/decomp_magician/format.py
+++ b/decomp_magician/format.py
@@ -15,6 +15,7 @@ from decomp_magician.classify import (
     DECOMP_TYPES,
     DecompType,
     DtensorStrategy,
+    get_dtensor_strategy,
     is_dtensor_gap,
     is_dtensor_intercept,
 )
@@ -88,8 +89,8 @@ def format_tree(
 
     lines.append(line)
 
-    this_has_dtensor = ancestor_has_dtensor or is_dtensor_intercept(
-        node.classification.dtensor_strategy
+    this_has_dtensor = ancestor_has_dtensor or (
+        cfg.show_dtensor and is_dtensor_intercept(get_dtensor_strategy(node.op))
     )
 
     child_prefix = prefix + ("    " if is_last else "│   ") if not is_root else ""
@@ -143,15 +144,16 @@ def _format_annotation(
                 annotation += "  " + _c(cfg, _GREEN, "mode-invariant")
 
     if cfg.show_dtensor:
-        if cls.dtensor_strategy == DtensorStrategy.REGISTERED:
+        dt_strat = get_dtensor_strategy(node.op)
+        if dt_strat == DtensorStrategy.REGISTERED:
             annotation += "  " + _c(cfg, _GREEN, "dtensor: registered")
-        elif cls.dtensor_strategy == DtensorStrategy.DECOMP_FALLBACK:
+        elif dt_strat == DtensorStrategy.DECOMP_FALLBACK:
             annotation += "  " + _c(cfg, _DIM, "dtensor: decomp-fallback")
-        elif cls.dtensor_strategy == DtensorStrategy.NOT_APPLICABLE:
+        elif dt_strat == DtensorStrategy.NOT_APPLICABLE:
             annotation += "  " + _c(cfg, _DIM, "dtensor: n/a")
-        elif cls.dtensor_strategy == DtensorStrategy.MISSING and ancestor_has_dtensor:
+        elif dt_strat == DtensorStrategy.MISSING and ancestor_has_dtensor:
             annotation += "  " + _c(cfg, _DIM, "dtensor: registered ancestor")
-        elif cls.dtensor_strategy == DtensorStrategy.MISSING:
+        elif dt_strat == DtensorStrategy.MISSING:
             annotation += "  " + _c(cfg, _RED, "dtensor: MISSING")
 
     return annotation
@@ -240,13 +242,14 @@ def format_summary(node: DecompNode, cfg: FormatConfig) -> str:
         counts[dt] = counts.get(dt, 0) + 1
         if n.classification.inductor_kept:
             inductor_kept += 1
-        if is_dtensor_gap(n.classification.dtensor_strategy) and not ancestor_covered:
+        dt_strat = get_dtensor_strategy(n.op) if cfg.show_dtensor else None
+        if dt_strat is not None and is_dtensor_gap(dt_strat) and not ancestor_covered:
             dtensor_missing += 1
         if not n.traceable:
             untraceable_nodes += 1
             untraceable_names.add(op_display_name(n.op))
-        covered = ancestor_covered or is_dtensor_intercept(
-            n.classification.dtensor_strategy
+        covered = ancestor_covered or (
+            dt_strat is not None and is_dtensor_intercept(dt_strat)
         )
         for c in n.children:
             walk(c, covered)
@@ -648,6 +651,8 @@ def format_verbose(node: DecompNode, cfg: FormatConfig, indent: int = 0) -> str:
     lines.append(f"{prefix}  autograd_type: {dinfo.autograd_type}")
     lines.append(f"{prefix}  has_adiov: {dinfo.has_adiov}")
     lines.append(f"{prefix}  mode_sensitive: {dinfo.mode_sensitive}")
+    if cfg.show_dtensor:
+        lines.append(f"{prefix}  dtensor_strategy: {get_dtensor_strategy(node.op)}")
     for child in node.children:
         lines.append(format_verbose(child, cfg, indent + 1))
     return "\n".join(lines)

--- a/decomp_magician/stats.py
+++ b/decomp_magician/stats.py
@@ -8,18 +8,33 @@ from dataclasses import dataclass
 
 from decomp_magician.classify import (
     DtensorStrategy, classify, get_all_decomposable_ops,
-    is_dtensor_gap, is_dtensor_intercept, is_out_variant,
+    get_dtensor_strategy, is_dtensor_gap, is_dtensor_intercept, is_out_variant,
 )
 from decomp_magician.tree import DecompNode, build_tree, op_display_name
 
 
 @dataclass(frozen=True)
 class DtensorStats:
-    """DTensor coverage statistics across all decomposable ops."""
+    """DTensor coverage statistics across all decomposable ops.
+
+    Two groups of fields with different denominators:
+
+    Per-op partition (static, verified by StatsResult invariant #4):
+      registered + decomp_fallback + missing + not_applicable = classified
+      Each op is counted exactly once based on get_dtensor_strategy().
+
+    Per-tree coverage (dynamic, approximate — depends on tracing):
+      fully_covered + has_gaps = traceable ops with children
+      Walks each successfully traced decomposition tree and checks whether
+      all leaf paths reach a DTensor-registered ancestor. Approximate because
+      the tree structure depends on which code paths synthetic inputs exercise.
+    """
+    # Per-op partition
     registered: int  # ops with a direct DTensor strategy
     decomp_fallback: int  # ops handled via decomposition tracing
     missing: int  # ops with no DTensor strategy at all
     not_applicable: int  # ops with no tensor inputs (unreachable by DTensor dispatch)
+    # Per-tree coverage
     fully_covered: int  # traceable ops where all leaf paths hit a registered ancestor
     has_gaps: int  # traceable ops with at least one uncovered leaf path
     top_uncovered: list[tuple[str, int]]  # most common uncovered leaf ops
@@ -92,8 +107,9 @@ def compute_stats(
     Args:
         compile: If True, treat inductor-kept ops as leaves.
         dtensor: If True, include DTensor coverage analysis in the result.
-                 Classification always includes DTensor strategy (it's intrinsic);
-                 this flag controls whether to aggregate and report it.
+                 DTensor strategy is a separate lookup (get_dtensor_strategy),
+                 not part of classify(). This flag controls whether to query
+                 and aggregate it.
     """
     all_ops = get_all_decomposable_ops()
     by_type: Counter[str] = Counter()
@@ -130,7 +146,7 @@ def compute_stats(
             inductor_kept += 1
 
         if dtensor:
-            dt_by_strategy[cls.dtensor_strategy] += 1
+            dt_by_strategy[get_dtensor_strategy(op)] += 1
 
         try:
             with warnings.catch_warnings():
@@ -209,11 +225,10 @@ def _collect_uncovered_dtensor(node: DecompNode) -> set[str]:
     uncovered: set[str] = set()
 
     def walk(n: DecompNode, ancestor_covered: bool = False) -> None:
-        covered = ancestor_covered or is_dtensor_intercept(
-            n.classification.dtensor_strategy
-        )
+        dt_strat = get_dtensor_strategy(n.op)
+        covered = ancestor_covered or is_dtensor_intercept(dt_strat)
         if not n.children:
-            if is_dtensor_gap(n.classification.dtensor_strategy) and not covered:
+            if is_dtensor_gap(dt_strat) and not covered:
                 uncovered.add(op_display_name(n.op))
             return
         for c in n.children:

--- a/decomp_magician/tree.py
+++ b/decomp_magician/tree.py
@@ -894,17 +894,18 @@ def collect_leaf_frontier(node: DecompNode) -> LeafFrontier:
     untraceable_ops: set[str] = set()
     dtensor_uncovered_ops: set[str] = set()
 
+    from decomp_magician.classify import get_dtensor_strategy
+
     def walk(n: DecompNode, ancestor_covered: bool = False) -> None:
-        covered = ancestor_covered or is_dtensor_intercept(
-            n.classification.dtensor_strategy
-        )
+        dt_strat = get_dtensor_strategy(n.op)
+        covered = ancestor_covered or is_dtensor_intercept(dt_strat)
         if not n.children:
             name = op_display_name(n.op)
             if n.classification.inductor_kept:
                 inductor_kept_ops.add(name)
             if not n.traceable:
                 untraceable_ops.add(name)
-            if is_dtensor_gap(n.classification.dtensor_strategy) and not covered:
+            if is_dtensor_gap(dt_strat) and not covered:
                 dtensor_uncovered_ops.add(name)
             return
         for c in n.children:

--- a/decomp_magician/tree.py
+++ b/decomp_magician/tree.py
@@ -887,25 +887,37 @@ class LeafFrontier(NamedTuple):
     dtensor_uncovered: set[str]
 
 
-def collect_leaf_frontier(node: DecompNode) -> LeafFrontier:
-    """Walk a tree and collect the leaf frontier with propagated counts."""
+def collect_leaf_frontier(
+    node: DecompNode, *, check_dtensor: bool = False,
+) -> LeafFrontier:
+    """Walk a tree and collect the leaf frontier with propagated counts.
+
+    Args:
+        check_dtensor: If True, check DTensor coverage for each leaf.
+            Only set when --dtensor is active — avoids importing
+            torch.distributed.tensor when DTensor analysis isn't requested.
+    """
     counts = collect_leaf_counts(node)
     inductor_kept_ops: set[str] = set()
     untraceable_ops: set[str] = set()
     dtensor_uncovered_ops: set[str] = set()
 
-    from decomp_magician.classify import get_dtensor_strategy
+    if check_dtensor:
+        from decomp_magician.classify import get_dtensor_strategy
 
     def walk(n: DecompNode, ancestor_covered: bool = False) -> None:
-        dt_strat = get_dtensor_strategy(n.op)
-        covered = ancestor_covered or is_dtensor_intercept(dt_strat)
+        if check_dtensor:
+            dt_strat = get_dtensor_strategy(n.op)
+            covered = ancestor_covered or is_dtensor_intercept(dt_strat)
+        else:
+            covered = ancestor_covered
         if not n.children:
             name = op_display_name(n.op)
             if n.classification.inductor_kept:
                 inductor_kept_ops.add(name)
             if not n.traceable:
                 untraceable_ops.add(name)
-            if is_dtensor_gap(dt_strat) and not covered:
+            if check_dtensor and is_dtensor_gap(dt_strat) and not covered:
                 dtensor_uncovered_ops.add(name)
             return
         for c in n.children:
@@ -922,6 +934,8 @@ def collect_untraceable_errors(node: DecompNode) -> list[tuple[str, str]]:
 
     def walk(n: DecompNode) -> None:
         if not n.traceable:
+            # n.error is guaranteed non-None by DecompNode invariant:
+            # ¬traceable → error is not None (checked in __post_init__)
             name = op_display_name(n.op)
             if name not in seen:
                 seen.add(name)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,8 +197,10 @@ class OpClass:
     is_mutable: bool
     has_alias_info: bool
     inductor_excluded: bool
-    dtensor_strategy: str | None  # "registered", "decomp-fallback", "missing", None
 ```
+
+DTensor strategy is a separate lookup via `get_dtensor_strategy(op)` — it queries the
+`ShardingPropagator` dicts and is independently cached in `_dtensor_cache`.
 
 | Field | How to compute |
 |-------|----------------|
@@ -208,7 +210,6 @@ class OpClass:
 | `is_mutable` | `op._schema.is_mutable` |
 | `has_alias_info` | `any(arg.alias_info for arg in op._schema.arguments)` |
 | `inductor_excluded` | In raw table but absent from Inductor's `select_decomp_table()` |
-| `dtensor_strategy` | Check `ShardingPropagator` dicts (lazy import, only with `--dtensor`) |
 
 ### `graph.py` — Graph Export
 

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -135,16 +135,16 @@ class TestTags:
 
 class TestDtensorStrategy:
     def test_always_populated(self):
-        """classify() always populates dtensor_strategy."""
+        """get_dtensor_strategy() always returns a valid strategy."""
+        from decomp_magician.classify import get_dtensor_strategy
         op = torch.ops.aten.mm.default
-        cls = classify(op)
-        assert cls.dtensor_strategy is not None
+        assert get_dtensor_strategy(op) is not None
 
     def test_leaf_op_is_missing(self):
         """A true leaf op (no decomposition) should be 'missing' or 'registered'."""
+        from decomp_magician.classify import get_dtensor_strategy
         op = torch.ops.aten.mm.default
-        cls = classify(op)
-        assert cls.dtensor_strategy in ("registered", "missing", "not-applicable")
+        assert get_dtensor_strategy(op) in ("registered", "missing", "not-applicable")
 
     def test_cia_op_never_missing(self):
         """Any op with _can_decompose()=True must not be 'missing'.
@@ -155,6 +155,7 @@ class TestDtensorStrategy:
         Samples ops at runtime so the test works across PyTorch versions.
         """
         from torch._ops import OpOverload
+        from decomp_magician.classify import get_dtensor_strategy
 
         checked = 0
         for name in dir(torch.ops.aten):
@@ -167,10 +168,10 @@ class TestDtensorStrategy:
                     continue
                 if not op._can_decompose():
                     continue
-                cls = classify(op)
-                assert cls.dtensor_strategy in ("registered", "decomp-fallback"), (
+                strat = get_dtensor_strategy(op)
+                assert strat in ("registered", "decomp-fallback"), (
                     f"{op.name()} has _can_decompose()=True but "
-                    f"dtensor_strategy={cls.dtensor_strategy!r}"
+                    f"dtensor_strategy={strat!r}"
                 )
                 checked += 1
                 if checked >= 20:
@@ -186,19 +187,10 @@ class TestOpClassValidation:
         with pytest.raises(ValueError, match="Invalid decomp_type"):
             OpClass(decomp_type="Table")
 
-    def test_invalid_dtensor_strategy_raises(self):
-        with pytest.raises(ValueError, match="Invalid dtensor_strategy"):
-            OpClass(decomp_type="leaf", dtensor_strategy="registred")
-
     def test_valid_decomp_types(self):
         for dt in ("CIA", "table", "both", "leaf"):
             cls = OpClass(decomp_type=dt)
             assert cls.decomp_type == dt
-
-    def test_valid_dtensor_strategies(self):
-        for ds in ("registered", "decomp-fallback", "missing", "not-applicable"):
-            cls = OpClass(decomp_type="leaf", dtensor_strategy=ds)
-            assert cls.dtensor_strategy == ds
 
     def test_inductor_kept_requires_table_decomp(self):
         """inductor_kept only makes sense for ops in the decomposition table."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -588,25 +588,25 @@ class TestDtensorAncestorCoverage:
     def test_leaves_shows_uncovered(self):
         leaf = self._make_node("missing")
         parent = self._make_node("decomp-fallback", children=[leaf])
-        output = format_leaves(parent, _CFG)
+        output = format_leaves(parent, self._DT_CFG)
         assert "MISSING" in output
 
     def test_leaves_hides_covered(self):
         leaf = self._make_node("missing")
         parent = self._make_node("registered", children=[leaf])
-        output = format_leaves(parent, _CFG)
+        output = format_leaves(parent, self._DT_CFG)
         assert "MISSING" not in output
 
     def test_json_leaves_uncovered_flag(self):
         leaf = self._make_node("missing")
         parent = self._make_node("decomp-fallback", children=[leaf])
-        d = leaves_to_dict(parent)
+        d = leaves_to_dict(parent, include_dtensor=True)
         assert any(entry.get("dtensor_uncovered") for entry in d["leaves"])
 
     def test_json_leaves_no_flag_when_covered(self):
         leaf = self._make_node("missing")
         parent = self._make_node("registered", children=[leaf])
-        d = leaves_to_dict(parent)
+        d = leaves_to_dict(parent, include_dtensor=True)
         assert not any(entry.get("dtensor_uncovered") for entry in d["leaves"])
 
     def test_cli_dtensor_decomposable_root_not_missing(self, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -516,11 +516,24 @@ class TestSourceFlag:
 class TestDtensorAncestorCoverage:
     _DT_CFG = FormatConfig(show_dtensor=True)
 
+    def setup_method(self):
+        from decomp_magician.classify import _dtensor_cache
+        self._mock_ops = []
+        self._dtensor_cache = _dtensor_cache
+
+    def teardown_method(self):
+        for op in self._mock_ops:
+            self._dtensor_cache.pop(op, None)
+
     def _make_node(self, strategy, children=()):
-        op = torch.ops.aten.mul.Tensor
+        from unittest.mock import MagicMock
+        # Create a unique mock op so _dtensor_cache maps each node independently
+        op = MagicMock(spec=torch.ops.aten.mul.Tensor)
+        op.name.return_value = "aten::mul.Tensor"
+        self._dtensor_cache[op] = strategy
+        self._mock_ops.append(op)
         cls = OpClass(
             decomp_type="leaf" if not children else "table",
-            dtensor_strategy=strategy,
         )
         return DecompNode(
             op=op, children=tuple(children), count=1,

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -296,12 +296,11 @@ class TestClassifyCache:
         cls2 = classify(op)
         assert cls1 is cls2
 
-    def test_classify_always_has_dtensor_strategy(self):
-        """classify() always populates dtensor_strategy (no None)."""
-        from decomp_magician.classify import classify
+    def test_get_dtensor_strategy_always_populated(self):
+        """get_dtensor_strategy() always returns a valid strategy."""
+        from decomp_magician.classify import get_dtensor_strategy
         op = torch.ops.aten.addcmul.default
-        cls = classify(op)
-        assert cls.dtensor_strategy is not None
+        assert get_dtensor_strategy(op) is not None
 
     def test_classify_returns_opclass(self):
         from decomp_magician.classify import classify


### PR DESCRIPTION
## Summary

- **Extract `dtensor_strategy` from `OpClass`** into a standalone `get_dtensor_strategy()` with its own `_dtensor_cache` — DTensor is a separate map over ops, not an intrinsic property of classification
- **Fully lazy DTensor initialization** — `_init_dtensor()` only fires when `--dtensor` is actually used, not on every `classify()` call. Threaded through `collect_leaf_frontier(check_dtensor=)`, `tree_to_dict(include_dtensor=)`, `leaves_to_dict(include_dtensor=)`, and all format functions via `cfg.show_dtensor`
- **Explicit dependency**: `get_dtensor_strategy()` calls `classify(op).decomp_type` to determine DECOMP_FALLBACK, making the map dependency clear rather than duplicating decomposition checks